### PR TITLE
feat: implement the bottom navigation

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -13,7 +13,9 @@ function getTabIndexFromLocation({ pathname }) {
   return 1;
 }
 
-export function Layout({ children, ...props }) {
+export function Layout(
+  { children, isBottomNavigationHidden = false, ...props },
+) {
   const location = useLocation();
   const navigate = useNavigate();
   const index = useMemo(() => getTabIndexFromLocation(location), [location]);
@@ -27,34 +29,36 @@ export function Layout({ children, ...props }) {
     >
       {children}
 
-      <BottomNavigation
-        showLabels
-        style={{
-          position: "fixed",
-          bottom: 0,
-          left: 0,
-          width: "100%",
-          zIndex: 20,
-        }}
-        value={index}
-        onChange={(event, newValue) => {
-          if (newValue === index) return;
-          navigate(
-            [
-              "/profiles",
-              "/challenges",
-              "/favorites",
-            ][newValue],
-          );
-        }}
-      >
-        <BottomNavigationAction label="Profile" icon={<PersonIcon />} />
-        <BottomNavigationAction
-          label="Challenges"
-          icon={<DirectionsWalkIcon />}
-        />
-        <BottomNavigationAction label="Favorites" icon={<FavoriteIcon />} />
-      </BottomNavigation>
+      {!isBottomNavigationHidden && (
+        <BottomNavigation
+          showLabels
+          style={{
+            position: "fixed",
+            bottom: 0,
+            left: 0,
+            width: "100%",
+            zIndex: 20,
+          }}
+          value={index}
+          onChange={(event, newValue) => {
+            if (newValue === index) return;
+            navigate(
+              [
+                "/profiles",
+                "/challenges",
+                "/favorites",
+              ][newValue],
+            );
+          }}
+        >
+          <BottomNavigationAction label="Profile" icon={<PersonIcon />} />
+          <BottomNavigationAction
+            label="Challenges"
+            icon={<DirectionsWalkIcon />}
+          />
+          <BottomNavigationAction label="Favorites" icon={<FavoriteIcon />} />
+        </BottomNavigation>
+      )}
     </Frame>
   );
 }

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -1,6 +1,23 @@
+import BottomNavigation from "@mui/material/BottomNavigation";
+import BottomNavigationAction from "@mui/material/BottomNavigationAction";
+import PersonIcon from "@mui/icons-material/Person";
+import FavoriteIcon from "@mui/icons-material/Favorite";
+import DirectionsWalkIcon from "@mui/icons-material/DirectionsWalk";
 import { Frame } from "./Frame";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useMemo } from "react";
+
+function getTabIndexFromLocation({ pathname }) {
+  if (pathname.startsWith("/profiles")) return 0;
+  if (pathname.startsWith("/favorites")) return 2;
+  return 1;
+}
 
 export function Layout({ children, ...props }) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const index = useMemo(() => getTabIndexFromLocation(location), [location]);
+
   return (
     <Frame
       wrapperStyle={{
@@ -9,6 +26,35 @@ export function Layout({ children, ...props }) {
       {...props}
     >
       {children}
+
+      <BottomNavigation
+        showLabels
+        style={{
+          position: "fixed",
+          bottom: 0,
+          left: 0,
+          width: "100%",
+          zIndex: 20,
+        }}
+        value={index}
+        onChange={(event, newValue) => {
+          if (newValue === index) return;
+          navigate(
+            [
+              "/profiles",
+              "/challenges",
+              "/favorites",
+            ][newValue],
+          );
+        }}
+      >
+        <BottomNavigationAction label="Profile" icon={<PersonIcon />} />
+        <BottomNavigationAction
+          label="Challenges"
+          icon={<DirectionsWalkIcon />}
+        />
+        <BottomNavigationAction label="Favorites" icon={<FavoriteIcon />} />
+      </BottomNavigation>
     </Frame>
   );
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -10,6 +10,8 @@ import { Challenges } from "./pages/challenges";
 import { Walk } from "./pages/challenges-slug-walk";
 import { Finish } from "./pages/challenges-slug-finish";
 import { Similarity } from "./pages/challenges-slug-similarity";
+import { Profile } from "./pages/profiles";
+import { Favorites } from "./pages/favorites";
 import { MapProvider } from "./components/Map";
 
 const router = createBrowserRouter([
@@ -32,6 +34,18 @@ const router = createBrowserRouter([
   {
     path: "/challenges/:slug/similarity",
     element: <Similarity />,
+  },
+  {
+    path: "/profiles",
+    element: <Profile />,
+  },
+  {
+    path: "/profiles/:id",
+    element: <Profile />,
+  },
+  {
+    path: "/favorites",
+    element: <Favorites />,
   },
 ]);
 

--- a/client/src/pages/challenges-slug-finish/index.jsx
+++ b/client/src/pages/challenges-slug-finish/index.jsx
@@ -7,6 +7,7 @@ export function Finish() {
 
   return (
     <Layout
+      isBottomNavigationHidden
       style={{
         display: "flex",
         flexDirection: "column",

--- a/client/src/pages/challenges-slug-similarity/index.jsx
+++ b/client/src/pages/challenges-slug-similarity/index.jsx
@@ -26,6 +26,7 @@ export function Similarity() {
 
   return (
     <Layout
+      isBottomNavigationHidden
       style={{
         display: "flex",
         flexDirection: "column",

--- a/client/src/pages/challenges-slug-walk/index.jsx
+++ b/client/src/pages/challenges-slug-walk/index.jsx
@@ -21,6 +21,7 @@ export function Walk() {
 
   return (
     <Layout
+      isBottomNavigationHidden
       style={{
         display: "flex",
         flexDirection: "column",

--- a/client/src/pages/favorites/index.jsx
+++ b/client/src/pages/favorites/index.jsx
@@ -1,0 +1,14 @@
+import { Layout } from "../../components/Layout";
+
+export function Favorites() {
+  return (
+    <Layout
+      style={{
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      Favorites!
+    </Layout>
+  );
+}

--- a/client/src/pages/profiles/index.jsx
+++ b/client/src/pages/profiles/index.jsx
@@ -1,0 +1,14 @@
+import { Layout } from "../../components/Layout";
+
+export function Profile() {
+  return (
+    <Layout
+      style={{
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      Profile!
+    </Layout>
+  );
+}


### PR DESCRIPTION
This closes #9 

This commit implements the following bottom navigation bar. It is hidden on pages where user walks.
Created dummy pages `Profile` and `Favorites` as well.

<img width="449" alt="image" src="https://github.com/gylman/artwalk/assets/22598138/a3ee331b-a6a9-439c-890a-d8967ce7c11e">

